### PR TITLE
Ajustar imports

### DIFF
--- a/sisred_app/tests.py
+++ b/sisred_app/tests.py
@@ -1172,11 +1172,10 @@ class RR02TestCase(TestCase):
 
     def test_get_version(self):
         url = '/api/get_version/'
-        fecha_inicio = datetime.strptime("2018-03-11", "%Y-%m-%d").date()
-        fecha_fin = datetime.strptime("2018-03-11", "%Y-%m-%d").date()
+        fecha = datetime.datetime.now()
         proyectto_conectate = ProyectoConectate.objects.create(id_conectate='1', nombre='prueba',
-                                                               codigo='prueba', fecha_inicio=fecha_inicio,
-                                                               fecha_fin=fecha_fin)
+                                                               codigo='prueba', fecha_inicio=fecha,
+                                                               fecha_fin=fecha)
         red = RED.objects.create(id_conectate='1', nombre='pruebaRED', descripcion='prueba',
                                  tipo='prueba', solicitante='prueba', proyecto_conectate=proyectto_conectate)
         version = Version.objects.create(numero=1, imagen='prueba', red=red, id=1)
@@ -1187,19 +1186,18 @@ class RR02TestCase(TestCase):
 
     def test_get_recursos(self):
         url = '/api/get_recursos_by_version/'
-        fecha_inicio = datetime.strptime("2018-03-11", "%Y-%m-%d").date()
-        fecha_fin = datetime.strptime("2018-03-11", "%Y-%m-%d").date()
+        fecha = datetime.datetime.now()
         proyectto_conectate = ProyectoConectate.objects.create(id_conectate='1', nombre='prueba',
-                                                               codigo='prueba', fecha_inicio=fecha_inicio,
-                                                               fecha_fin=fecha_fin)
+                                                               codigo='prueba', fecha_inicio=fecha,
+                                                               fecha_fin=fecha)
         red = RED.objects.create(id_conectate='1', nombre='pruebaRED', descripcion='prueba',
                                  tipo='prueba', solicitante='prueba', proyecto_conectate=proyectto_conectate)
         version = Version.objects.create(numero=1, imagen='prueba', red=red, id=1)
         user_model = User.objects.create_user(username='user1', password='1234ABC*', first_name='Usuario',
                                               last_name='uno', email='user1@coquito.com')
         perfil = Perfil.objects.create(id_conectate='1', usuario=user_model, estado=1)
-        recurso = version.recursos.create(nombre='prueba', archivo='prueba', thumbnail='prueba', fecha_creacion=fecha_inicio,
-                                          fecha_ultima_modificacion=fecha_inicio, tipo='prueba', descripcion='prueba',
+        recurso = version.recursos.create(nombre='prueba', archivo='prueba', thumbnail='prueba', fecha_creacion=fecha,
+                                          fecha_ultima_modificacion=fecha, tipo='prueba', descripcion='prueba',
                                           autor=perfil, usuario_ultima_modificacion=perfil)
         response = self.client.get(url, {'id': '1'})
         current_data = json.loads(response.content)


### PR DESCRIPTION
Cuando se integraron los test, se usó este import: 
import datetime
mientras que en nuestro equipo teníamos este:
from datetime import datetime
Lo que hacia que nosotros al usar esta función: 
datetime.strptime("2018-03-11", "%Y-%m-%d").date()
se generara un error. Para solucionarlo no cambiamos el import sino la forma como se crea la fecha de pruebas siguiendo a los otros test